### PR TITLE
Add option to show 'Terminal' label next to the icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Show a terminal icon in status bar, click to focus integrated terminal.
 
 - `terminal-in-status-bar.statusBarAlignment`: Status bar alignment, left or right.
 - `terminal-in-status-bar.statusBarPriority`: Status bar priority. Higher means more to the left.
+- `terminal-in-status-bar.statusBarLabel`: If a label should be shown in the status bar next to the icon.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
           "terminal-in-status-bar.statusBarPriority": {
             "type": "number",
             "description": "Status bar priority. Higher means more to the left."
+          },
+          "terminal-in-status-bar.statusBarLabel": {
+            "type": "boolean",
+            "description": "If a label should be shown in the status bar next to the icon."
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 const id = "terminal-in-status-bar";
 const ALIGNMENT_KEY = "statusBarAlignment";
 const PRIORITY_KEY = "statusBarPriority";
+const LABEL_KEY = "statusBarLabel";
 let statusBarItem: vscode.StatusBarItem;
 
 // this method is called when your extension is activated
@@ -19,7 +20,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (
         event.affectsConfiguration(`${id}.${ALIGNMENT_KEY}`) ||
-        event.affectsConfiguration(`${id}.${PRIORITY_KEY}`)
+        event.affectsConfiguration(`${id}.${PRIORITY_KEY}`) ||
+        event.affectsConfiguration(`${id}.${LABEL_KEY}`)
       ) {
         statusBarItem.dispose();
         showStatusBarItem(context);
@@ -47,11 +49,12 @@ function showStatusBarItem(context: vscode.ExtensionContext) {
       ? vscode.StatusBarAlignment.Right
       : vscode.StatusBarAlignment.Left;
   const priority = conf.get<number>(PRIORITY_KEY);
+  const showLabel = conf.get<boolean>(LABEL_KEY);
   console.log("load config:", alignment, priority);
 
   statusBarItem = vscode.window.createStatusBarItem(alignment, priority);
   statusBarItem.command = "terminal-in-status-bar.toggle";
-  statusBarItem.text = "$(terminal)";
+  statusBarItem.text = `$(terminal)${showLabel ? " Terminal" : ""}`;
   statusBarItem.tooltip = "Toggle Integrated Terminal";
   context.subscriptions.push(statusBarItem);
   statusBarItem.show();


### PR DESCRIPTION
This change adds a setting to show a label next to the terminal icon to make it easier to click. There's [a similar extension](https://github.com/fuadpashayev/vscode-ext-bottom-terminal) that already does this (without any option to show just the icon), but yours is currently the most popular and configurable status bar terminal extension so I think it'd be nice to have this as an option.

I left the option defaulted off.

Example:
![image](https://github.com/flyfly6/terminal-in-status-bar/assets/10302670/31630fa5-1511-457c-b6ce-ce5b01fe25da)
